### PR TITLE
feat(tmux): add 3-pane split layout template

### DIFF
--- a/cmd/deploy/main.go
+++ b/cmd/deploy/main.go
@@ -52,7 +52,7 @@ func allTargets() []target {
 	return []target{
 		{name: "zsh", src: "zshrc", dest: filepath.Join(home, ".zshrc"), command: "zsh"},
 		{name: "nvim", src: "nvim", dest: filepath.Join(home, ".config", "nvim"), isDir: true, command: "nvim"},
-		{name: "tmux", src: "tmux.conf", dest: filepath.Join(home, ".tmux.conf"), command: "tmux"},
+		{name: "tmux", src: "tmux.conf", dest: filepath.Join(home, ".config", "tmux", "tmux.conf"), command: "tmux"},
 		{name: "aerospace", src: "aerospace.toml", dest: filepath.Join(home, ".aerospace.toml"), command: "aerospace"},
 		{name: "ghostty", src: "config.ghostty", dest: filepath.Join(home, ".config", "ghostty", "config")},
 		{name: "git", src: "gitconfig", dest: filepath.Join(home, ".gitconfig"), command: "git"},

--- a/deploy.sh
+++ b/deploy.sh
@@ -139,7 +139,7 @@ do_backup() {
     case "$t" in
       zsh)       [[ -f "$HOME/.zshrc" ]] && needs_backup=true ;;
       nvim)      [[ -d "$HOME/.config/nvim" ]] && needs_backup=true ;;
-      tmux)      [[ -f "$HOME/.tmux.conf" ]] && needs_backup=true ;;
+      tmux)      [[ -f "$HOME/.config/tmux/tmux.conf" ]] && needs_backup=true ;;
       aerospace) [[ -f "$HOME/.aerospace.toml" ]] && needs_backup=true ;;
       ghostty)   [[ -f "$HOME/.config/ghostty/config" ]] && needs_backup=true ;;
       git)       [[ -f "$HOME/.gitconfig" ]] && needs_backup=true ;;
@@ -157,7 +157,7 @@ do_backup() {
     case "$t" in
       zsh)       backup_file "$HOME/.zshrc" ;;
       nvim)      backup_file "$HOME/.config/nvim" ;;
-      tmux)      backup_file "$HOME/.tmux.conf" ;;
+      tmux)      backup_file "$HOME/.config/tmux/tmux.conf" ;;
       aerospace) backup_file "$HOME/.aerospace.toml" ;;
       ghostty)   backup_file "$HOME/.config/ghostty/config" ;;
       git)       backup_file "$HOME/.gitconfig" ;;
@@ -198,8 +198,9 @@ deploy() {
       ;;
 
     tmux)
-      if cp "$SCRIPT_DIR/tmux.conf" "$HOME/.tmux.conf" 2>/dev/null; then
-        success "tmux" "tmux.conf" "$HOME/.tmux.conf"
+      mkdir -p "$HOME/.config/tmux"
+      if cp "$SCRIPT_DIR/tmux.conf" "$HOME/.config/tmux/tmux.conf" 2>/dev/null; then
+        success "tmux" "tmux.conf" "$HOME/.config/tmux/tmux.conf"
         DEPLOYED=$((DEPLOYED + 1))
       else
         fail "tmux" "failed to copy tmux.conf"

--- a/tmux.conf
+++ b/tmux.conf
@@ -1,6 +1,7 @@
 # ==========================
 # General Options
 # ==========================
+set -g history-limit 1000000
 set-option -g mouse on
 set -g base-index 1
 set -g pane-base-index 1

--- a/tmux.conf
+++ b/tmux.conf
@@ -28,6 +28,9 @@ bind-key -n C-Down select-pane -D
 # Create 4 split panes (2x2 grid)
 bind-key g split-window -h \; split-window -v \; select-pane -t 0 \; split-window -v
 
+# Create 3 split panes (main top-left 70%, sidebar top-right 30%, bottom 25%)
+bind-key G split-window -v -p 25 \; select-pane -t 0 \; split-window -h -p 30 \; select-pane -t 0
+
 # Copy mode vim-style bindings
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"

--- a/tmux.conf
+++ b/tmux.conf
@@ -30,7 +30,7 @@ bind-key -n C-Down select-pane -D
 bind-key g split-window -h \; split-window -v \; select-pane -t 0 \; split-window -v
 
 # Create 3 split panes (main top-left 70%, sidebar top-right 30%, bottom 25%)
-bind-key G split-window -v -p 25 \; select-pane -t 0 \; split-window -h -p 30 \; select-pane -t 0
+bind-key G split-window -v \; select-pane -U \; split-window -h \; resize-pane -t 2 -x 30% \; resize-pane -t 3 -y 25% \; select-pane -t 1
 
 # Copy mode vim-style bindings
 bind-key -T copy-mode-vi v send-keys -X begin-selection


### PR DESCRIPTION
## Summary

- Add new tmux keybinding `prefix + G` (Shift+G) for a 3-pane split layout
- Fix tmux deploy path from `~/.tmux.conf` to `~/.config/tmux/tmux.conf`
- Increase tmux history limit to 1M lines

## Layout (prefix + G)

```
|  70%   | 30% |   <- 75% height
|        |     |
|--------|-----|
|    100%      |   <- 25% height
|--------------|
```

Focus lands on the top-left (main) pane after creation.

## Changes

- `tmux.conf`: Add `bind-key G` with resize-pane for accurate percentages
- `tmux.conf`: Add `set -g history-limit 1000000`
- `cmd/deploy/main.go`: Update tmux dest to `~/.config/tmux/tmux.conf`
- `deploy.sh`: Update tmux path in backup, check, and deploy logic

## Usage

Press `Ctrl-a + G` to create the 3-pane layout.