### PR TITLE
fix(tmux): preserve working directory on pane splits

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -27,10 +27,10 @@ bind-key -n C-Up select-pane -U
 bind-key -n C-Down select-pane -D
 
 # Create 4 split panes (2x2 grid)
-bind-key g split-window -h \; split-window -v \; select-pane -t 0 \; split-window -v
+bind-key g split-window -h -c "#{pane_current_path}" \; split-window -v -c "#{pane_current_path}" \; select-pane -t 0 \; split-window -v -c "#{pane_current_path}"
 
 # Create 3 split panes (main top-left 70%, sidebar top-right 30%, bottom 25%)
-bind-key G split-window -v \; select-pane -U \; split-window -h \; resize-pane -t 2 -x 30% \; resize-pane -t 3 -y 25% \; select-pane -t 1
+bind-key G split-window -v -c "#{pane_current_path}" \; select-pane -U \; split-window -h -c "#{pane_current_path}" \; resize-pane -t 2 -x 30% \; resize-pane -t 3 -y 25% \; select-pane -t 1
 
 # Copy mode vim-style bindings
 bind-key -T copy-mode-vi v send-keys -X begin-selection


### PR DESCRIPTION
## Summary

- Add `-c "#{pane_current_path}"` to split-window commands
- Both `prefix + g` (2x2 grid) and `prefix + G` (3-pane layout) now open splits in the same directory as the current pane